### PR TITLE
Fixes bug with aBSREL branch selection.

### DIFF
--- a/app/models/absrel.js
+++ b/app/models/absrel.js
@@ -36,6 +36,13 @@ aBSREL.virtual("filepath").get(function() {
 });
 
 /**
+ * Original file path for document's file upload
+ */
+aBSREL.virtual("original_fn").get(function() {
+  return path.resolve(__dirname + "/../../uploads/msa/" + this._id + "-original." + this.original_extension);
+});
+
+/**
  * Filename of document's file upload
  */
 aBSREL.virtual("status_stack").get(function() {


### PR DESCRIPTION
Fix for veg/hyphy#760. The issue arises with concatenated alignments/trees (i.e., CD2.fna). Similar to an issue encountered with Relax: https://github.com/veg/datamonkey-js/pull/59.