### PR TITLE
Account for fasta being unavailable

### DIFF
--- a/app/templates/absrel/results.ejs
+++ b/app/templates/absrel/results.ejs
@@ -5,13 +5,22 @@
 
 <script>
 
+  var fasta_ready = false
+
   d3.json(window.location.href+"/fasta", (err, data) => {
     var fasta = data.fasta
+    fasta_ready = true;
 
     $(document).ready( function () {
       hyphyVision.absrel($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
     });
 
   });
+
+  if (fasta_ready == false) {
+    $(document).ready( function () {
+      hyphyVision.absrel($("#job-report").data('jobid') + '/results', "content", null, true, true)
+    });
+  }
 
 </script>

--- a/app/templates/busted/results.ejs
+++ b/app/templates/busted/results.ejs
@@ -5,13 +5,22 @@
 
 <script>
 
+  var fasta_read = false;
+
   d3.json(window.location.href+"/fasta", (err, data) => {
     var fasta = data.fasta
+    fasta_ready = true;
 
     $(document).ready( function () {
       hyphyVision.busted($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
     });
 
   });
+
+  if (fasta_ready == false) {
+    $(document).ready( function () {
+      hyphyVision.busted($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
+    });
+  }
 
 </script>

--- a/app/templates/fel/results.ejs
+++ b/app/templates/fel/results.ejs
@@ -5,13 +5,22 @@
 
 <script>
 
+  var fasta_read = false;
+
   d3.json(window.location.href+"/fasta", (err, data) => {
     var fasta = data.fasta
+    fasta_ready = true;
 
     $(document).ready( function () {
       hyphyVision.fel($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
     });
 
   });
+
+  if (fasta_ready == false) {
+    $(document).ready( function () {
+      hyphyVision.fel($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
+    });
+  }
 
 </script>

--- a/app/templates/fubar/results.ejs
+++ b/app/templates/fubar/results.ejs
@@ -5,13 +5,22 @@
 
 <script>
 
+  var fasta_read = false;
+
   d3.json(window.location.href+"/fasta", (err, data) => {
     var fasta = data.fasta
+    fasta_ready = true;
 
     $(document).ready( function () {
       hyphyVision.fubar($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
     });
 
   });
+
+  if (fasta_ready == false) {
+    $(document).ready( function () {
+      hyphyVision.fubar($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
+    });
+  }
 
 </script>

--- a/app/templates/gard/results.ejs
+++ b/app/templates/gard/results.ejs
@@ -5,13 +5,22 @@
 
 <script>
 
+  var fasta_read = false;
+
   d3.json(window.location.href+"/fasta", (err, data) => {
     var fasta = data.fasta
+    fasta_ready = true;
 
     $(document).ready( function () {
       hyphyVision.gard($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
     });
 
   });
+
+  if (fasta_ready == false) {
+    $(document).ready( function () {
+      hyphyVision.gard($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
+    });
+  }
 
 </script>

--- a/app/templates/meme/results.ejs
+++ b/app/templates/meme/results.ejs
@@ -5,13 +5,22 @@
 
 <script>
 
+  var fasta_read = false;
+
   d3.json(window.location.href+"/fasta", (err, data) => {
     var fasta = data.fasta
+    fasta_ready = true;
 
     $(document).ready( function () {
       hyphyVision.meme($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
     });
 
   });
+
+  if (fasta_ready == false) {
+    $(document).ready( function () {
+      hyphyVision.meme($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
+    });
+  }
 
 </script>

--- a/app/templates/relax/results.ejs
+++ b/app/templates/relax/results.ejs
@@ -5,13 +5,22 @@
 
 <script>
 
+  var fasta_read = false;
+
   d3.json(window.location.href+"/fasta", (err, data) => {
     var fasta = data.fasta
+    fasta_ready = true;
 
     $(document).ready( function () {
       hyphyVision.relax($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
     });
 
   });
+
+  if (fasta_ready == false) {
+    $(document).ready( function () {
+      hyphyVision.relax($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
+    });
+  }
 
 </script>

--- a/app/templates/slac/results.ejs
+++ b/app/templates/slac/results.ejs
@@ -5,13 +5,22 @@
 
 <script>
 
+  var fasta_read = false;
+
   d3.json(window.location.href+"/fasta", (err, data) => {
     var fasta = data.fasta
+    fasta_ready = true;
 
     $(document).ready( function () {
       hyphyVision.slac($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
     });
 
   });
+
+  if (fasta_ready == false) {
+    $(document).ready( function () {
+      hyphyVision.slac($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
+    });
+  }
 
 </script>


### PR DESCRIPTION
As it was previously set-up, the vision page would not render at all if the fasta file wasn't available (which is the case when trying to develop locally and view a file that was run on datamonkey.org). This PR rectifies this by rendering the vision page without the fasta file (null is passed into the component so everything else is fine, the "view MSA" button just won't be in the dropdown.

@mli24970 you should be able to pull these changes down and view results files now.