### PR TITLE
1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express-busboy": "^2.4.4",
     "express-validator": "^2.21.0",
     "hivtrace-viz": "^0.0.14",
-    "hyphy-vision": "2.1.4",
+    "hyphy-vision": "2.1.5",
     "jade": "^1.0.0",
     "jquery-file-upload": "^4.0.5",
     "jquery-file-upload-middleware": "^0.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datamonkey.js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A free public server for comparative analysis of sequence alignments using state-of-the-art statistical models.",
   "private": true,
   "author": {


### PR DESCRIPTION
Merging develop into master so that the production site can use the version 2.1.5 of hyphy-vision which addresses the issue with the "export-to-csv" button (see [this vision issue](https://github.com/veg/hyphy-vision/pull/174) and [this hyphy issue](https://github.com/veg/hyphy/issues/844)).

This is already live on staging.datamonkey.org.