### PR TITLE
BGM original file and analysis log features

### DIFF
--- a/app/templates/bgm/results.ejs
+++ b/app/templates/bgm/results.ejs
@@ -6,7 +6,7 @@
 <script>
 
   $(document).ready( function () {
-    hyphyVision.bgm($("#job-report").data('jobid') + '/results', "content")
+    hyphyVision.bgm($("#job-report").data('jobid') + '/results', "content", false, true, true);
   });
 
 </script>

--- a/config/routes.js
+++ b/config/routes.js
@@ -209,6 +209,7 @@ module.exports = function(app) {
   app.get("/slac/:id/results", _.partial(analysis.getResults, SLAC));
   app.get("/slac/:id/cancel", slac.cancel);
   app.get("/slac/:id/log.txt", slac.getLog);
+  slac.resubscribePendingJobs();
 
   // BGM ROUTES
   bgm = require(path.join(__dirname, "../app/routes/bgm"));
@@ -216,10 +217,10 @@ module.exports = function(app) {
   app.post("/bgm", bgm.invoke);
   app.get("/bgm/usage", bgm.getUsage);
   app.get("/bgm/:id", bgm.getPage);
+  app.get("/bgm/:id/original_file/:name", bgm.getMSAFile);
   app.get("/bgm/:id/info", _.partial(analysis.getInfo, BGM));
   app.get("/bgm/:id/results", _.partial(analysis.getResults, BGM));
   app.get("/bgm/:id/cancel", bgm.cancel);
   app.get("/bgm/:id/log.txt", bgm.getLog);
   bgm.resubscribePendingJobs();
-  slac.resubscribePendingJobs();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datamonkey.js",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A free public server for comparative analysis of sequence alignments using state-of-the-art statistical models.",
   "private": true,
   "author": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express-busboy": "^2.4.4",
     "express-validator": "^2.21.0",
     "hivtrace-viz": "^0.0.14",
-    "hyphy-vision": "2.4.2",
+    "hyphy-vision": "2.5.0-alpha.2",
     "jade": "^1.0.0",
     "jquery-file-upload": "^4.0.5",
     "jquery-file-upload-middleware": "^0.1.8",


### PR DESCRIPTION
This PR adds the ability to obtain the original file and analysis log from completed BGM jobs, and is currently live on http://staging.datamonkey.org.

HyPhy Vision is bumped because I believe version 2.4.2 was published with code coming from the application webpack configuration, and not the library one... see the attached screenshot, which is the main page when building from the current `master` branch of `datamonkey-js`. This is replicated when `yalc` linking with the wrong webpack config, and disappears when yalc linking with the correct one (the `appendChild` call is made in the call to `render_app`, which should not be made in Datamonkey).

2.5.0-alpha was missing `dist/application.scss`.

Hence I chose 2.5.0-alpha.2, which is the newest available version after these two, and seems to work.

![image](https://user-images.githubusercontent.com/8673708/55354518-f93d9880-5493-11e9-8fa8-cfc59e73be7b.png)
