### PR TITLE
Fixes bug for obtaining partitioned data from GARD.

### DIFF
--- a/app/templates/gard/results.ejs
+++ b/app/templates/gard/results.ejs
@@ -12,14 +12,14 @@
     fasta_ready = true;
 
     $(document).ready( function () {
-      hyphyVision.gard($("#job-report").data('jobid') + '/results', "content", fasta, true, true)
+      hyphyVision.gard($("#job-report").data('jobid') + '/results', "content", fasta, true, true, true)
     });
 
   });
 
   if (fasta_ready == false) {
     $(document).ready( function () {
-      hyphyVision.gard($("#job-report").data('jobid') + '/results', "content", null, true, true)
+      hyphyVision.gard($("#job-report").data('jobid') + '/results', "content", null, true, true, true)
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datamonkey.js",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A free public server for comparative analysis of sequence alignments using state-of-the-art statistical models.",
   "private": true,
   "author": {
@@ -27,7 +27,7 @@
     "express-busboy": "^2.4.4",
     "express-validator": "^2.21.0",
     "hivtrace-viz": "^0.0.14",
-    "hyphy-vision": "2.5.0-alpha.2",
+    "hyphy-vision": "2.4.3",
     "jade": "^1.0.0",
     "jquery-file-upload": "^4.0.5",
     "jquery-file-upload-middleware": "^0.1.8",


### PR DESCRIPTION
Self descriptive.

Note hyphy-vision 2.4.3 has not yet been released, but is the subject of [this pull request](https://github.com/veg/hyphy-vision/pull/191). Tested with `yalc`.