### PR TITLE
HyPhy 2.5 (bump vision to 2.5.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ dump.rdb
 .DS_Store
 .yalc/
 yalc.lock
+2.2.6*
+v1.0.2*

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express-busboy": "^2.4.4",
     "express-validator": "^2.21.0",
     "hivtrace-viz": "^0.0.14",
-    "hyphy-vision": "2.4.3",
+    "hyphy-vision": "2.5.0",
     "jade": "^1.0.0",
     "jquery-file-upload": "^4.0.5",
     "jquery-file-upload-middleware": "^0.1.8",

--- a/public/assets/js/job.js
+++ b/public/assets/js/job.js
@@ -29,12 +29,9 @@ function setupJob() {
 
   var socket_address = document.location.origin;
 
-  var socket = io.connect(
-    socket_address,
-    {
-      reconnect: true
-    }
-  );
+  var socket = io.connect(socket_address, {
+    reconnect: true
+  });
 
   var was_error = false;
 
@@ -148,7 +145,7 @@ function setupJob() {
   });
 
   socket.on("script error", function(data) {
-    $("#modal-error-msg").html(msg);
+    $("#modal-error-msg").html(data);
     $("#errorModal").modal();
   });
 


### PR DESCRIPTION
Bump to the newest version of HyPhy Vision which will be needed for HyPhy 2.5 to view the new GARD json. This will allow HyPhy 2.5 to be deployed to the staging site. We can then work on the items in #193.

Also corrects a simple error in `job.js`


