### PR TITLE
Bump HyPhy Vision to 2.8.11.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "express-busboy": "^2.4.4",
     "express-validator": "^2.21.0",
     "hivtrace-viz": "^0.0.14",
-    "hyphy-vision": "2.8.8",
+    "hyphy-vision": "^2.8.11",
     "jade": "^1.0.0",
     "jquery-file-upload": "^4.0.5",
     "jquery-file-upload-middleware": "^0.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7091,47 +7091,6 @@ husky@^0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-hyphy-vision@2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hyphy-vision/-/hyphy-vision-2.8.8.tgz#341448226ae2aab72dd653f3ef18d9ca2b0e200f"
-  integrity sha512-hULJmCWwXDbHERp1qR4EM5kEIBp4qSO7C6G2UD2kV50+ymnZLIQVCccU9Thy2rMfbIUYaQnEZ6MI/PTSbJ/1Rw==
-  dependencies:
-    "@fortawesome/fontawesome-free" "^5.12.1"
-    alignment.js "0.3.0"
-    bootstrap "4.x"
-    chi-squared "^1.1.0"
-    circos "^2.1.0"
-    create-react-class "^15.6.3"
-    d3 "3.x"
-    d3-save-svg "0.0.2"
-    export-to-csv "^0.2.1"
-    express "^4.16.2"
-    file-saver "^2.0.2"
-    immutable "3.8.2"
-    in-browser-download "^1.0.0"
-    jquery "3.x"
-    jquery-ui "1.x"
-    jquery-ui-bundle "^1.11.4"
-    jquery-ui-dist "^1.12.1"
-    json-loader "^0.5.7"
-    lodash "4.x"
-    lodash.clonedeep "^4.5.0"
-    phylotree "0.1.6"
-    popper.js "^1.14.1"
-    pretty-data "^0.40.0"
-    prop-types "^15.5.10"
-    react "16.12.0"
-    react-copy-to-clipboard "^5.0.0"
-    react-dom "16.12.0"
-    react-json-view "^1.14.0"
-    react-phylotree "0.4.1"
-    react-range "^1.5.3"
-    react-router-dom "^5.1.2"
-    react-router-hash-link "^1.1.1"
-    react-scrollchor "^6.0.0"
-    save-svg-as-png "^1.2.0"
-    underscore "1.9"
-
 hyphy-vision@^1.0.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hyphy-vision/-/hyphy-vision-1.1.7.tgz#ddd641aa3faff31d17064c50c58beb21c91cb08d"
@@ -7166,6 +7125,47 @@ hyphy-vision@^1.0.0:
     react-json-view "^1.14.0"
     save-svg-as-png "^1.2.0"
     underscore "^1.8.3"
+
+hyphy-vision@^2.8.11:
+  version "2.8.11"
+  resolved "https://registry.yarnpkg.com/hyphy-vision/-/hyphy-vision-2.8.11.tgz#37b693a311fd18acf573d75ff41958f343cf5c41"
+  integrity sha512-d8xEPwAg8Q7p3b78prM81Y6X0RALvs4wlAppi9Y5f0pABXz3zF2wbPC2CD6utD7H+UUNi6g/KdHoXH1+e5R7YQ==
+  dependencies:
+    "@fortawesome/fontawesome-free" "^5.12.1"
+    alignment.js "0.3.0"
+    bootstrap "4.x"
+    chi-squared "^1.1.0"
+    circos "^2.1.0"
+    create-react-class "^15.6.3"
+    d3 "3.x"
+    d3-save-svg "0.0.2"
+    export-to-csv "^0.2.1"
+    express "^4.16.2"
+    file-saver "^2.0.2"
+    immutable "3.8.2"
+    in-browser-download "^1.0.0"
+    jquery "3.x"
+    jquery-ui "1.x"
+    jquery-ui-bundle "^1.11.4"
+    jquery-ui-dist "^1.12.1"
+    json-loader "^0.5.7"
+    lodash "4.x"
+    lodash.clonedeep "^4.5.0"
+    phylotree "0.1.6"
+    popper.js "^1.14.1"
+    pretty-data "^0.40.0"
+    prop-types "^15.5.10"
+    react "16.13.1"
+    react-copy-to-clipboard "^5.0.0"
+    react-dom "16.13.1"
+    react-json-view "^1.14.0"
+    react-phylotree "0.4.3"
+    react-range "^1.5.3"
+    react-router-dom "^5.1.2"
+    react-router-hash-link "^2.0.0"
+    react-scrollchor "^6.0.0"
+    save-svg-as-png "^1.2.0"
+    underscore "1.9"
 
 iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.13, iconv-lite@^0.4.4, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.24"
@@ -10627,7 +10627,7 @@ react-deep-force-update@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.2.tgz#3d2ae45c2c9040cbb1772be52f8ea1ade6ca2ee1"
   integrity sha512-WUSQJ4P/wWcusaH+zZmbECOk7H5N2pOIl0vzheeornkIMhu+qrNdGFm0bDZLCb0hSF0jf/kH1SgkNGfBdTc4wA==
 
-react-dom@16.12, react-dom@16.12.0:
+react-dom@16.12:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
   integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==
@@ -10636,6 +10636,16 @@ react-dom@16.12, react-dom@16.12.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.18.0"
+
+react-dom@16.13.1, react-dom@^16.13.0, react-dom@^16.6.3:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
+  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
 
 react-dom@^15.4.1:
   version "15.6.2"
@@ -10646,16 +10656,6 @@ react-dom@^15.4.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
-
-react-dom@^16.13.0, react-dom@^16.6.3:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
-  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
 
 react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
@@ -10748,6 +10748,21 @@ react-phylotree@0.4.1:
     react "16.12.0"
     underscore "^1.9.1"
 
+react-phylotree@0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/react-phylotree/-/react-phylotree-0.4.3.tgz#6f5698140aa7d8b2b2dec75aaaca3a1a3bb55939"
+  integrity sha512-abWRvsylEeWNmAUBP4iIeSKFvrEWH3I3oV+PCuIoZUbVHylhEhppbugC1vBX5MFZlCJPXOvBfFFZ3QB4ZV6q+w==
+  dependencies:
+    "@fortawesome/fontawesome-svg-core" "^1.2.10"
+    "@fortawesome/free-solid-svg-icons" "^5.6.1"
+    "@fortawesome/react-fontawesome" "^0.1.3"
+    bootstrap "4.3.1"
+    d3 "^5.7.0"
+    d3-react-axis "0.0.3"
+    phylotree "1.0.0-alpha.17"
+    react "^16.13.0"
+    underscore "^1.9.1"
+
 react-proxy@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-1.1.8.tgz#9dbfd9d927528c3aa9f444e4558c37830ab8c26a"
@@ -10791,12 +10806,12 @@ react-router-dom@^5.1.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router-hash-link@^1.1.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/react-router-hash-link/-/react-router-hash-link-1.2.2.tgz#7a0ad5e925d49596d19554de8bc6c554ce4f8099"
-  integrity sha512-LBthLVHdqPeKDVt3+cFRhy15Z7veikOvdKRZRfyBR2vjqIE7rxn+tKLjb6DOmLm6JpoQVemVDnxQ35RVnEHdQA==
+react-router-hash-link@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-router-hash-link/-/react-router-hash-link-2.3.1.tgz#2ebe3443caad4d478a76e484458f1974f24ee97c"
+  integrity sha512-QVYLaBLmRGovSbQv4Tbjqnl9JMEQ8c5rWebkZU16ovgZtpmNIf2znGj3uWaKkAL7lhuYBPcC3OAfhw7lk/QwNw==
   dependencies:
-    prop-types "^15.6.0"
+    prop-types "^15.7.2"
 
 react-router@5.2.0:
   version "5.2.0"
@@ -10892,7 +10907,7 @@ react@16.12, react@16.12.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
-react@^16.12.0, react@^16.13.0, react@^16.6.3:
+react@16.13.1, react@^16.12.0, react@^16.13.0, react@^16.6.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
This is a fix for veg/hyphy#1271. BUSTED does not seem to currently work (here is the [CD2 dataset ran on production](http://datamonkey.org/busted/600767d892b0773656e60927)). A simple bump to the latest version of hyphy-vision appears to resolve this, [as seen on my development instance](http://sshank.datamonkey.org/busted/600754c4c1c3f00569456337).

I will deploy this to production once it is merged.