### PR TITLE
#752 -- New analysis options

### DIFF
--- a/app/models/fel.js
+++ b/app/models/fel.js
@@ -15,6 +15,16 @@ var FEL = mongoose.Schema({
   resample: Number,
   ci: Boolean,
   bootstrap: Boolean,
+  multiple_hits: {
+    type: String,
+    enum: ["None", "Double", "Double+Triple"],
+    default: "None",
+  },
+  site_multihit: {
+    type: String,
+    enum: ["Estimate", "Global"],
+    default: "Estimate",
+  },
 });
 
 FEL.add(AnalysisSchema);
@@ -47,7 +57,7 @@ FEL.virtual("original_fn").get(function () {
       "/../../uploads/msa/" +
       this._id +
       "-original." +
-      this.original_extension
+      this.original_extension,
   );
 });
 
@@ -123,7 +133,7 @@ FEL.statics.spawn = function (fn, options, callback) {
         } else {
           var move = Msa.removeTreeFromFile(
             fel_result.filepath,
-            fel_result.filepath
+            fel_result.filepath,
           );
           move.then(
             (val) => {
@@ -137,7 +147,7 @@ FEL.statics.spawn = function (fn, options, callback) {
             },
             (reason) => {
               callback(err, "issue removing tree from file");
-            }
+            },
           );
         }
       }

--- a/app/models/meme.js
+++ b/app/models/meme.js
@@ -12,6 +12,10 @@ var MEME = mongoose.Schema({
   results: Object,
   resample: Number,
   bootstrap: Boolean,
+  multiple_hits: String,
+  site_multihit: String,
+  rates: Number,
+  impute_states: String,
 });
 
 MEME.add(AnalysisSchema);
@@ -113,13 +117,13 @@ MEME.statics.spawn = function (fn, options, callback) {
           logger.error(
             "meme rename failed" +
               " Errored on line 113~ within models/meme.js :: move_cb " +
-              err
+              err,
           );
           callback(err, null);
         } else {
           var move = Msa.removeTreeFromFile(
             meme_result.filepath,
-            meme_result.filepath
+            meme_result.filepath,
           );
           move.then(
             (val) => {
@@ -130,7 +134,7 @@ MEME.statics.spawn = function (fn, options, callback) {
             },
             (reason) => {
               res.json(500, { error: "issue removing tree from file" });
-            }
+            },
           );
         }
       }

--- a/app/models/meme.js
+++ b/app/models/meme.js
@@ -112,7 +112,6 @@ MEME.statics.spawn = function (fn, options, callback) {
         } else {
           Msa.removeTreeFromFile(meme_result.filepath, meme_result.filepath)
             .then(() => {
-              meme.upload_redirect_path = meme.upload_redirect_path;
               this.submitJob(meme_result, connect_callback);
               callback(null, meme);
             })

--- a/app/models/meme.js
+++ b/app/models/meme.js
@@ -53,50 +53,41 @@ MEME.virtual("url").get(function () {
   return "http://" + setup.host + "/meme/" + this._id;
 });
 
-/**
- * Shared API / Web request job spawn
- */
+
 MEME.statics.spawn = function (fn, options, callback) {
   const Msa = mongoose.model("Msa");
-  var meme = new this();
+  const meme = new this();
 
-  let gencodeid = options.gencodeid,
-    datatype = options.datatype;
-
-  meme.mail = options.mail;
+  // Dynamically add all options to the meme object
+  Object.keys(options).forEach((key) => {
+    meme[key] = options[key];
+  });
 
   // Check advanced options
-  if (!_.isNaN(options.resample)) {
-    meme.resample = options.resample;
-    meme.bootstrap = true;
-  } else {
-    meme.bootstrap = false;
-  }
+  meme.bootstrap = !_.isNaN(options.resample);
 
   const connect_callback = function (data) {
-    if (data == "connected") {
+    if (data === "connected") {
       logger.log("connected");
     }
   };
 
-  Msa.parseFile(fn, datatype, gencodeid, (err, msa) => {
+  Msa.parseFile(fn, options.datatype, options.gencodeid, (err, msa) => {
     if (err) {
       callback(err);
       return;
     }
+
     // Check if msa exceeds limitations
     if (msa.sites > meme.max_sites) {
-      const error =
-        "Site limit exceeded! Sites must be less than " + meme.max_sites;
+      const error = `Site limit exceeded! Sites must be less than ${meme.max_sites}`;
       logger.error(error);
       callback(error);
       return;
     }
 
     if (msa.sequences > meme.max_sequences) {
-      var error =
-        "Sequence limit exceeded! Sequences must be less than " +
-        meme.max_sequences;
+      const error = `Sequence limit exceeded! Sequences must be less than ${meme.max_sequences}`;
       logger.error(error);
       callback(error);
       return;
@@ -112,32 +103,25 @@ MEME.statics.spawn = function (fn, options, callback) {
         return;
       }
 
-      function move_cb(err, result) {
+      function move_cb(err) {
         if (err) {
           logger.error(
-            "meme rename failed" +
-              " Errored on line 113~ within models/meme.js :: move_cb " +
-              err,
+            `meme rename failed. Error on line 113~ within models/meme.js :: move_cb ${err}`,
           );
           callback(err, null);
         } else {
-          var move = Msa.removeTreeFromFile(
-            meme_result.filepath,
-            meme_result.filepath,
-          );
-          move.then(
-            (val) => {
-              let to_send = meme;
-              to_send.upload_redirect_path = meme.upload_redirect_path;
+          Msa.removeTreeFromFile(meme_result.filepath, meme_result.filepath)
+            .then(() => {
+              meme.upload_redirect_path = meme.upload_redirect_path;
               this.submitJob(meme_result, connect_callback);
               callback(null, meme);
-            },
-            (reason) => {
-              res.json(500, { error: "issue removing tree from file" });
-            },
-          );
+            })
+            .catch(() => {
+              callback(new Error("issue removing tree from file"));
+            });
         }
       }
+
       helpers.moveSafely(fn, meme_result.filepath, move_cb.bind(this));
     });
   });

--- a/app/models/msa.js
+++ b/app/models/msa.js
@@ -65,12 +65,12 @@ Msa.virtual("genetic_code").get(function () {
 });
 
 Msa.virtual("day_created_on").get(function () {
-  var time = moment(this.timestamp);
+  var time = moment.unix(this.timestamp);
   return time.format("YYYY-MMM-DD");
 });
 
 Msa.virtual("time_created_on").get(function () {
-  var time = moment(this.timestamp);
+  var time = moment.unix(this.timestamp);
   return time.format("HH:mm");
 });
 

--- a/app/routes/fel.js
+++ b/app/routes/fel.js
@@ -25,6 +25,7 @@ exports.uploadFile = function (req, res) {
     }
   };
 
+
   var fn = req.files.files.file,
     fel = new FEL(),
     postdata = req.body,
@@ -32,6 +33,7 @@ exports.uploadFile = function (req, res) {
     gencodeid = postdata.gencodeid,
     ds_variation = postdata.ds_variation,
     resample = parseInt(postdata.resample);
+
 
   fel.original_extension = path.basename(fn).split(".")[1];
   fel.mail = postdata.mail;
@@ -150,8 +152,6 @@ exports.invoke = function (req, res) {
     // User Parameters
     fel.tagged_nwk_tree = postdata.nwk_tree;
     fel.analysis_type = postdata.analysis_type;
-    fel.multiple_hits = postdata.multiple_hits; // new
-    fel.site_multihit = postdata.site_multihit; // new
     fel.status = fel.status_stack[0];
 
     fel.save(function (err, result) {

--- a/app/routes/fel.js
+++ b/app/routes/fel.js
@@ -36,6 +36,8 @@ exports.uploadFile = function (req, res) {
   fel.original_extension = path.basename(fn).split(".")[1];
   fel.mail = postdata.mail;
   fel.ci = postdata.confidence_interval == "true";
+  fel.multiple_hits = postdata.multiple_hits;
+  fel.site_multihit = postdata.site_multihit;
 
   // Check advanced options
   if (!_.isNaN(resample)) {
@@ -87,7 +89,7 @@ exports.uploadFile = function (req, res) {
         } else {
           var move = Msa.removeTreeFromFile(
             fel_result.filepath,
-            fel_result.filepath
+            fel_result.filepath,
           );
           move.then(
             (val) => {
@@ -98,7 +100,7 @@ exports.uploadFile = function (req, res) {
             },
             (reason) => {
               res.json(500, { error: "issue removing tree from file" });
-            }
+            },
           );
         }
       }
@@ -116,7 +118,7 @@ exports.uploadFile = function (req, res) {
           helpers.moveSafely(
             req.files.files.file,
             fel_result.filepath,
-            move_cb
+            move_cb,
           );
         });
       });
@@ -148,6 +150,8 @@ exports.invoke = function (req, res) {
     // User Parameters
     fel.tagged_nwk_tree = postdata.nwk_tree;
     fel.analysis_type = postdata.analysis_type;
+    fel.multiple_hits = postdata.multiple_hits; // new
+    fel.site_multihit = postdata.site_multihit; // new
     fel.status = fel.status_stack[0];
 
     fel.save(function (err, result) {

--- a/app/routes/meme.js
+++ b/app/routes/meme.js
@@ -18,8 +18,6 @@ exports.form = function (req, res) {
 exports.invoke = function (req, res) {
   var fn = req.files.files.file;
   let postdata = req.body;
-  //let resample = parseInt(postdata.resample);
-  console.log(postdata)
 
   let options = {
     datatype: 0,

--- a/app/routes/meme.js
+++ b/app/routes/meme.js
@@ -19,6 +19,7 @@ exports.invoke = function (req, res) {
   var fn = req.files.files.file;
   let postdata = req.body;
   //let resample = parseInt(postdata.resample);
+  console.log(postdata)
 
   let options = {
     datatype: 0,

--- a/app/routes/meme.js
+++ b/app/routes/meme.js
@@ -24,6 +24,11 @@ exports.invoke = function (req, res) {
     datatype: 0,
     gencodeid: postdata.gencodeid,
     mail: postdata.mail,
+    multiple_hits: postdata.multiple_hits,
+    site_multihit: postdata.site_multihit,
+    rates: parseInt(postdata.rates),
+    resample: parseInt(postdata.resample || 0),
+    impute_states: postdata.impute_states,
   };
 
   //// Check advanced options

--- a/app/templates/fel/msa_form.ejs
+++ b/app/templates/fel/msa_form.ejs
@@ -88,6 +88,22 @@
         </select>
       </div>
 
+      <div class="form-group">
+        <label for="multiple-hits">Multiple Hits</label>
+        <select name="multiple_hits" id="multiple-hits">
+          <option value="None">None (Single mutations only)</option>
+          <option value="Double">Double (Branch-specific rates for double substitutions)</option>
+          <option value="Double+Triple">Double+Triple (Branch-specific rates for double and triple substitutions)</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label for="estimated-rates">Site Multihit</label>
+        <select name="site_multihit" id="site-multihit">
+          <option value="Estimate">Estimate (Branch-specific rates for substitutions based on model fit)</option>
+          <option value="Global">Global (Rates derived from global model fit)</option>
+        </select>
+      </div>
 
       <div class="form-group <%if (typeof errors != "undefined" && typeof errors.mail != "undefined") { %>has-error<% } %>">
         <label id="datatype-content" class="control-label">Notify When Completed?</label>

--- a/app/templates/meme/form.ejs
+++ b/app/templates/meme/form.ejs
@@ -1,7 +1,7 @@
 <%- include("../includes/header.ejs") %>
 <div id="container" class="container">
   <%- include("header.ejs") %>
-  <%- include("../partials/msa/form.ejs") %>
+  <%- include("./msa_form.ejs") %>
   <%- include("../includes/modal.ejs") %>
 </div>
 <%- include("../includes/footer.ejs") %>

--- a/app/templates/meme/msa_form.ejs
+++ b/app/templates/meme/msa_form.ejs
@@ -1,136 +1,131 @@
-<%- include("../includes/header.ejs") %>
-<div id="container" class="container">
-  <%- include("header.ejs") %>
+<!--
+<div class="nav nav-list span4i">
+  <a href="/help" target="_blank"><span class="glyphicon glyphicon-info-sign"></span></a>
+</div>
+-->
 
-  <!--
-  <div class="nav nav-list span4i">
-    <a href="/help" target="_blank"><span class="glyphicon glyphicon-info-sign"></span></a>
-  </div>
-  -->
+<div class="row">  
 
-  <div class="row">  
+  <form id="msa-form" class="form-horizontal upload-form col-12" name="uploadform" enctype="multipart/form-data" method="post" action=<%= post_to %>>
 
-    <form id="msa-form" class="form-horizontal upload-form col-12" name="uploadform" enctype="multipart/form-data" method="post" action=<%= post_to %>>
-
-      <div id="seq-file-div" class="upload-div">
-          <input id="seq-file" type="file" name="files">
-          <div id="file-progress" class="progress progress-striped active hidden">
-              <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="1" aria-valuemax="100">
-                <span class="sr-only">0% Complete</span>
-              </div>
-          </div>  
-      </div>
-
-      <div class="upload-div">
-        <label id="geneticcode-content">Genetic Code<a href="/help#genetic-code" target="_blank"><sup>?</sup></a></label>
-        <select name="gencodeid">
-
-          <option value="0">
-            Universal code
-          </option>
-
-          <option value="1">
-            Vertebrate mitochondrial DNA code
-          </option>
-
-          <option value="2">
-            Yeast mitochondrial DNA code
-          </option>
-
-          <option value="3">
-            Mold, Protozoan and Coelenterate mt;
-            Mycloplasma/Spiroplasma
-          </option>
-
-          <option value="4">
-            Invertebrate mitochondrial DNA code
-          </option>
-
-          <option value="5">
-            Ciliate, Dasycladacean and Hexamita Nuclear code
-          </option>
-
-          <option value="6">
-            Echinoderm mitochondrial DNA code
-          </option>
-
-          <option value="7">
-            Euplotid Nuclear code
-          </option>
-
-          <option value="8">
-            Alternative Yeast Nuclear code
-          </option>
-
-          <option value="9">
-            Ascidian mitochondrial DNA code
-          </option>
-
-          <option value="10">
-            Flatworm mitochondrial DNA code
-          </option>
-
-          <option value="11">
-            Blepharisma Nuclear code
-          </option>
-
-        </select> 
-      </div>
-
-      <div class="form-group <%if (typeof errors != "undefined" && typeof errors.mail != "undefined") { %>has-error<% } %>">
-        <label id="datatype-content">Notify When Completed</label>
-        <input name="mail" type="text" class="form-control" placeholder="Email Address">
-      </div><!-- /form-group -->
-
-      <div class="accordion" id="accordionExample">
-        <div class="card">
-          <div class="card-header" id="headingOne">
-            <h5 class="mb-0">
-              <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-                Advanced Options
-              </button>
-            </h5>
-          </div>
-
-          <div id="collapseOne" class="collapse show" aria-labelledby="headingOne" data-parent="#accordionExample">
-            <div class="card-body">
-              <div class="resample">
-                <p>[Advanced setting, will result in MUCH SLOWER run time] Perform parametric bootstrap resampling to derive site-level null LRT distributions up to this many replicates per site. Recommended use for small to medium (<30 sequences) datasets.</p>
-                <label>Resample?</label>
-                <input type="number" id="resample" name="resample" placeholder="50" min="0" max="1000">
-              </div>
+    <div id="seq-file-div" class="upload-div">
+        <input id="seq-file" type="file" name="files">
+        <div id="file-progress" class="progress progress-striped active hidden">
+            <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="1" aria-valuemax="100">
+              <span class="sr-only">0% Complete</span>
             </div>
-          </div>
-        </div>
-      </div>
-
-
-      <button id="submit-button" type="submit" class="dm-continue-btn btn float-right">
-        Run Analysis 
-        <span class="fa fa-play"></span></button>
-      </button>
-
-    </form>
-  </div>
-
-  </div>
-
-  <script src="/assets/js/msa/form.js"></script>
-
-
-
-<div aria-labelledby="errorModalLabel" role="dialog" id="errorModal" class="modal ng-scope">
-  <div class="modal-dialog"><div class="modal-content">
-    <div class="modal-header dialog-header-error">
-      <button data-dismiss="modal" class="close" type="button">×</button>
-      <h4 class="modal-title text-danger"><span class="glyphicon glyphicon-warning-sign"></span> Error</h4>
-      </div>
-      <div id="modal-error-msg" class="modal-body text-danger">This is my error message</div>
-      <div class="modal-footer">
-        <button data-dismiss="modal" class="btn btn-primary" type="button">Close</button>
-      </div>
+        </div>  
     </div>
-  </div>
+
+    <div class="upload-div">
+      <label id="geneticcode-content">Genetic Code<a href="/help#genetic-code" target="_blank"><sup>?</sup></a></label>
+      <select name="gencodeid">
+
+        <option value="0">
+          Universal code
+        </option>
+
+        <option value="1">
+          Vertebrate mitochondrial DNA code
+        </option>
+
+        <option value="2">
+          Yeast mitochondrial DNA code
+        </option>
+
+        <option value="3">
+          Mold, Protozoan and Coelenterate mt;
+          Mycloplasma/Spiroplasma
+        </option>
+
+        <option value="4">
+          Invertebrate mitochondrial DNA code
+        </option>
+
+        <option value="5">
+          Ciliate, Dasycladacean and Hexamita Nuclear code
+        </option>
+
+        <option value="6">
+          Echinoderm mitochondrial DNA code
+        </option>
+
+        <option value="7">
+          Euplotid Nuclear code
+        </option>
+
+        <option value="8">
+          Alternative Yeast Nuclear code
+        </option>
+
+        <option value="9">
+          Ascidian mitochondrial DNA code
+        </option>
+
+        <option value="10">
+          Flatworm mitochondrial DNA code
+        </option>
+
+        <option value="11">
+          Blepharisma Nuclear code
+        </option>
+
+      </select> 
+    </div>
+
+    <div class="upload-div">
+      <label for="multiple-hits">Multiple Hits</label>
+      <select name="multiple_hits" id="multiple-hits">
+        <option value="None">None</option>
+        <option value="Double">Double</option>
+        <option value="Double+Triple">Double+Triple</option>
+      </select>
+    </div>
+
+    <div class="upload-div">
+      <label for="site-multihit">Site Multihit</label>
+      <select name="site_multihit" id="site-multihit">
+        <option value="Estimate">Estimate</option>
+        <option value="Global">Global</option>
+      </select>
+    </div>
+
+    <div class="upload-div">
+      <label for="rates">Rates</label>
+      <select name="rates" id="rates">
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+      </select>
+    </div>
+
+    <div class="upload-div">
+      <label for="resample">Resample</label>
+      <input type="number" id="resample" name="resample" min="0" placeholder="0">
+    </div>
+
+    <div class="upload-div">
+      <label for="impute-states">Impute States</label>
+      <select name="impute_states" id="impute-states">
+        <option value="No">No</option>
+        <option value="Yes">Yes</option>
+      </select>
+    </div>
+
+    <div class="form-group <%if (typeof errors != "undefined" && typeof errors.mail != "undefined") { %>has-error<% } %>">
+      <label id="datatype-content">Notify When Completed</label>
+      <input name="mail" type="text" class="form-control" placeholder="Email Address">
+    </div><!-- /form-group -->
+
+    <button id="submit-button" type="submit" class="dm-continue-btn btn float-right">
+      Run Analysis 
+      <span class="fa fa-play"></span></button>
+    </button>
+
+  </form>
 </div>
 
-<%- include("../includes/footer.ejs") %>
+</div>
+
+<script src="/assets/js/msa/form.js"></script>
+

--- a/app/templates/meme/msa_form.ejs
+++ b/app/templates/meme/msa_form.ejs
@@ -127,5 +127,5 @@
 
 </div>
 
-<script src="/assets/js/msa/form.js"></script>
+<script src="/assets/js/meme/form.js"></script>
 

--- a/public/assets/js/fel/msa_form.js
+++ b/public/assets/js/fel/msa_form.js
@@ -13,17 +13,19 @@ $(function () {
     formData.append("gencodeid", $("select[name='gencodeid']").val());
     formData.append("ds_variation", $("#ds-variation").val());
     formData.append("resample", $("#resample").val());
+    formData.append("multiple_hits", $("select[name='multiple_hits']").val());
+    formData.append("site_multihit", $("select[name='site_multihit']").val());
 
     formData.append(
       "receive_mail",
-      $("input[name='receive_mail']").prop("checked")
+      $("input[name='receive_mail']").prop("checked"),
     );
 
     formData.append("mail", $("input[name='mail']").val());
 
     formData.append(
       "confidence_interval",
-      $("input[name='confidence-interval']").prop("checked")
+      $("input[name='confidence-interval']").prop("checked"),
     );
 
     var action_url = $("#msa-form").attr("action");
@@ -64,7 +66,7 @@ $(function () {
         window.location.href = result.upload_redirect_path;
       } else {
         $("#modal-error-msg").text(
-          "We received data in an unexpected format from the server."
+          "We received data in an unexpected format from the server.",
         );
         $("#errorModal").modal();
         $("#file-progress").css("display", "none");

--- a/public/assets/js/fel/msa_form.js
+++ b/public/assets/js/fel/msa_form.js
@@ -1,4 +1,24 @@
 $(function () {
+  function toggleSiteMultihit() {
+    const multipleHitsValue = $("#multiple-hits").val();
+    const siteMultihitDropdown = $("#site-multihit");
+
+    if (multipleHitsValue === "None") {
+      siteMultihitDropdown.prop("disabled", true);
+      siteMultihitDropdown.val("Estimate"); // Set to default value if disabled
+    } else {
+      siteMultihitDropdown.prop("disabled", false);
+    }
+  }
+
+  // Initial check on page load
+  toggleSiteMultihit();
+
+  // Bind change event to multiple_hits dropdown
+  $("#multiple-hits").change(function () {
+    toggleSiteMultihit();
+  });
+
   $("form").submit(function (e) {
     e.preventDefault();
 
@@ -13,19 +33,19 @@ $(function () {
     formData.append("gencodeid", $("select[name='gencodeid']").val());
     formData.append("ds_variation", $("#ds-variation").val());
     formData.append("resample", $("#resample").val());
-    formData.append("multiple_hits", $("select[name='multiple_hits']").val());
-    formData.append("site_multihit", $("select[name='site_multihit']").val());
+    formData.append("multiple_hits", $("#multiple-hits").val());
+    formData.append("site_multihit", $("#site-multihit").val());
 
     formData.append(
       "receive_mail",
-      $("input[name='receive_mail']").prop("checked"),
+      $("input[name='receive_mail']").prop("checked")
     );
 
     formData.append("mail", $("input[name='mail']").val());
 
     formData.append(
       "confidence_interval",
-      $("input[name='confidence-interval']").prop("checked"),
+      $("input[name='confidence-interval']").prop("checked")
     );
 
     var action_url = $("#msa-form").attr("action");
@@ -66,7 +86,7 @@ $(function () {
         window.location.href = result.upload_redirect_path;
       } else {
         $("#modal-error-msg").text(
-          "We received data in an unexpected format from the server.",
+          "We received data in an unexpected format from the server."
         );
         $("#errorModal").modal();
         $("#file-progress").css("display", "none");

--- a/public/assets/js/meme/form.js
+++ b/public/assets/js/meme/form.js
@@ -1,0 +1,68 @@
+$(function () {
+  $("form").submit(function (e) {
+    e.preventDefault();
+
+    $("#file-progress").removeClass("hidden");
+
+    var formData = new FormData();
+    var file = document.getElementById("seq-file").files[0];
+    var filename = document.getElementById("seq-file").files[0].name;
+
+    formData.append("files", file);
+    formData.append("datatype", $("select[name='datatype']").val());
+    formData.append("gencodeid", $("select[name='gencodeid']").val());
+    formData.append("mail", $("input[name='mail']").val());
+
+    var action_url = $("#msa-form").attr("action");
+
+    var xhr = new XMLHttpRequest();
+
+    xhr.open("post", action_url, true);
+
+    xhr.upload.onprogress = function (e) {
+      if (e.lengthComputable) {
+        var percentage = (e.loaded / e.total) * 100;
+
+        $("#seq-file").css("display", "none");
+        $(".progress .progress-bar").css("width", percentage + "%");
+      }
+    };
+
+    xhr.onerror = function (e) {
+      $("#file-progress").html(e);
+    };
+
+    xhr.onload = function (res) {
+      // Replace field with green text, name of file
+      var result = JSON.parse(this.responseText);
+
+      if (_.has(result, "error")) {
+        $("#modal-error-msg").text(result.error);
+        $("#errorModal").modal();
+        $("#file-progress").css("display", "none");
+        $("#seq-file").css("display", "block");
+        $(".progress .progress-bar").css("width", "0%");
+      } else if ("error" in result.analysis) {
+        $("#modal-error-msg").text(result.analysis.error);
+        $("#errorModal").modal();
+        $("#file-progress").css("display", "none");
+        $("#seq-file").css("display", "block");
+        $(".progress .progress-bar").css("width", "0%");
+      } else if ("upload_redirect_path" in result) {
+        window.location.href = result.upload_redirect_path;
+      } else {
+        $("#modal-error-msg").text(
+          "We received data in an unexpected format from the server."
+        );
+        $("#errorModal").modal();
+        $("#file-progress").css("display", "none");
+        $("#seq-file").css("display", "block");
+        $(".progress .progress-bar").css("width", "0%");
+      }
+    };
+
+    xhr.send(formData);
+  });
+
+  $(".mail-group").change(datamonkey.helpers.validate_email);
+});


### PR DESCRIPTION
This pull request introduces several key enhancements to our FEL and MEME models, particularly focusing on the new parameters `multiple_hits` and `site_multihit`, which will allow for more flexible analyses. Additionally, there are adjustments made to the front-end templates and JavaScript that enable users to select these options conveniently. Below are some highlights from the changes:

- Modified FEL and MEME schemas to include the new fields:
  - `multiple_hits`: String with options "None", "Double", "Double+Triple".
  - `site_multihit`: String with options "Estimate" and "Global".

- The forms for both FEL and MEME have been updated to include dropdowns for these new options, enhancing the user interface.

- JavaScript functions have been added/updated to manage dynamic behaviors concerning the new fields, particularly controlling the state of the `site_multihit` dropdown based on the selection of `multiple_hits`.

- Cleaned up some code for better readability, including template adjustments and improved error handling on file uploads.