### PR TITLE
Raise max_sequences limits for larger alignments

### DIFF
--- a/app/models/absrel.js
+++ b/app/models/absrel.js
@@ -28,7 +28,7 @@ aBSREL.virtual("upload_redirect_path").get(function () {
 });
 
 aBSREL.virtual("max_sequences").get(function () {
-  return 1000;
+  return 2500;
 });
 
 /**

--- a/app/models/analysis.js
+++ b/app/models/analysis.js
@@ -59,7 +59,7 @@ AnalysisSchema.virtual("max_sites").get(function () {
 });
 
 AnalysisSchema.virtual("max_sequences").get(function () {
-  return 5000;
+  return 10000;
 });
 
 AnalysisSchema.virtual("input_data").get(function () {

--- a/app/models/bgm.js
+++ b/app/models/bgm.js
@@ -28,7 +28,7 @@ BGM.virtual("analysistype").get(function () {
 });
 
 BGM.virtual("max_sequences").get(function () {
-  return 1000;
+  return 1500;
 });
 
 BGM.virtual("upload_redirect_path").get(function () {

--- a/app/models/busted.js
+++ b/app/models/busted.js
@@ -25,7 +25,7 @@ Busted.virtual("pmid").get(function () {
 });
 
 Busted.virtual("max_sequences").get(function () {
-  return 1000;
+  return 2000;
 });
 
 /**

--- a/app/models/contrast-fel.js
+++ b/app/models/contrast-fel.js
@@ -29,7 +29,7 @@ ContrastFEL.virtual("upload_redirect_path").get(function () {
 });
 
 ContrastFEL.virtual("max_sequences").get(function () {
-  return 2000;
+  return 5000;
 });
 
 /**

--- a/app/models/fubar.js
+++ b/app/models/fubar.js
@@ -27,7 +27,7 @@ FUBAR.virtual("upload_redirect_path").get(function () {
 });
 
 FUBAR.virtual("max_sequences").get(function () {
-  return 10000;
+  return 25000;
 });
 
 /**

--- a/app/models/relax.js
+++ b/app/models/relax.js
@@ -24,7 +24,7 @@ Relax.virtual("pmid").get(function () {
 });
 
 Relax.virtual("max_sequences").get(function () {
-  return 1000;
+  return 2000;
 });
 
 /**


### PR DESCRIPTION
## Summary
Raises per-method `max_sequences` limits so users can submit larger alignments. These caps hadn't been revisited in years and were the practical constraint on datamonkey.org (most methods stopped at 1000 sequences).

Values were derived from the DM3 timing calculator (`timingEstimates.js` power-law runtime fits), inverting each method's equation to find the max sequences finishing within a ~12h budget at 1000 sites on the 32-core backend config.

| Method | Old | New |
|---|---:|---:|
| base (fel/meme/slac) | 5000 | 10000 |
| fubar | 10000 | 25000 |
| contrast-fel | 2000 | 5000 |
| absrel | 1000 | 2500 |
| relax | 1000 | 2000 |
| busted | 1000 | 2000 |
| bgm | 1000 | 1500 |

**Left unchanged:** GARD and multi-hit stay at 1000 — runtime is superlinear in taxa and they are the methods most prone to walltime timeouts. `max_sites` (base 32000) unchanged; real uploads top out ~12k.

**Note:** these limits assume the backend runs methods at ~32 procs (matching the production config); at lower core counts the larger MEME/BUSTED/RELAX jobs would risk walltime timeouts.
